### PR TITLE
New release for iOS

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: scrapmechanic_kurtlourens_com
 description: A companion app for Scrap Mechanic.
 publish_to: 'none'
-version: 1.7.1+45
+version: 1.7.2+46
 
 environment:
   sdk: '>=2.7.0 <3.0.0'


### PR DESCRIPTION
iOS update rejected because the AssistantApps Flutter CommonLib mentions there are android apps. Problem fixed there, resubmitting iOS update 🙄